### PR TITLE
Lion build error fixed

### DIFF
--- a/mobiruby-ios.xcodeproj/project.pbxproj
+++ b/mobiruby-ios.xcodeproj/project.pbxproj
@@ -562,6 +562,8 @@
 					"\"$(SRCROOT)/mruby/build\"",
 					"\"$(SRCROOT)/mruby/build/i386/test\"",
 					"\"$(SRCROOT)/mobiruby-ios\"",
+					"\"$(SRCROOT)/submodules/mruby/build\"",
+					"\"$(SRCROOT)/submodules/libffi/build\"",
 				);
 				OTHER_CFLAGS = (
 					"-I$(PROJECT_DIR)/submodules/mruby/include",
@@ -604,6 +606,8 @@
 					"\"$(SRCROOT)/mruby/build\"",
 					"\"$(SRCROOT)/mruby/build/i386/test\"",
 					"\"$(SRCROOT)/mobiruby-ios\"",
+					"\"$(SRCROOT)/submodules/mruby/build\"",
+                                        "\"$(SRCROOT)/submodules/libffi/build\"",
 				);
 				OTHER_CFLAGS = (
 					"-DNS_BLOCK_ASSERTIONS=1",
@@ -646,6 +650,8 @@
 					"\"$(SRCROOT)/mruby/build\"",
 					"\"$(SRCROOT)/mruby/build/libffi\"",
 					"\"$(SRCROOT)/mruby/build/i386/test\"",
+					"\"$(SRCROOT)/submodules/mruby/build\"",
+                                        "\"$(SRCROOT)/submodules/libffi/build\"",
 				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
@@ -685,6 +691,8 @@
 					"\"$(SRCROOT)/mruby/build\"",
 					"\"$(SRCROOT)/mruby/build/libffi\"",
 					"\"$(SRCROOT)/mruby/build/i386/test\"",
+					"\"$(SRCROOT)/submodules/mruby/build\"",
+                                        "\"$(SRCROOT)/submodules/libffi/build\"",
 				);
 				OTHER_CFLAGS = (
 					"-DNS_BLOCK_ASSERTIONS=1",

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -10,6 +10,7 @@ DEBUG_APP_DIR = 'build/Debug-iphonesimulator/mobiruby-ios.app'
 
 source_files = Dir.glob('src/**/*.rb')
 file 'tmp/src.c' => source_files + [MRBC] do |t|
+  FileUtils.mkdir_p 'tmp'
   FileUtils.rm_f t.name
   source_files.each do |filename|
     funcname = filename.relative_path_from('src').gsub('/','_').gsub(/\..*/, '')

--- a/tasks/os_version.rake
+++ b/tasks/os_version.rake
@@ -2,8 +2,8 @@
 XCODE_VERSION = /Xcode\s+(\d+\.\d+)/.match(`xcodebuild -version`).to_a[1].to_f
 OSX_VERSION = /(\d+\.\d+)/.match(`uname -r`).to_a[1].to_f
 
-if XCODE_VERSION < 4.6 || OSX_VERSION < 12.2
-  puts "MobiRuby required Mountain Lion / Xcode 4.6 or newer version."
+if XCODE_VERSION < 4.6 || OSX_VERSION < 11.4
+  puts "MobiRuby required Lion or Mountain Lion / Xcode 4.6 or newer version."
   exit 1
 end
 

--- a/tasks/simulator.rake
+++ b/tasks/simulator.rake
@@ -1,7 +1,7 @@
 IOS_SIM = './bin/ios-sim'
 
 file IOS_SIM do
-  sh %Q{cd ios-sim; rake install prefix=../}
+  sh %Q{cd ./submodules/ios-sim; rake install prefix=../../}
 end
 
 desc 'Run your app on iOS simulator'


### PR DESCRIPTION
I've responded to the build error on Lion. 
some of error messages are like below.

ld: library not found for -lmruby
ld: library not found for -lffi

The problem seems like rake task.  This fixes work good.
