### PR TITLE
adopt to Xcode 5.0.2 with iOS 7 simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ And then, type the commands in terminal:
 ```
 git clone https://github.com/mobiruby/mobiruby-ios.git
 cd mobiruby-ios
+git checkout develop
 rake
 ```
 

--- a/bin/build-config.sh
+++ b/bin/build-config.sh
@@ -4,5 +4,7 @@
 
 PLATFORM_IOS=`xcode-select -print-path`"/Platforms/iPhoneOS.platform/"
 PLATFORM_IOS_SIM=`xcode-select -print-path`"/Platforms/iPhoneSimulator.platform/"
+GCC_PLATFORM_IOS=`xcode-select -print-path`
+GCC_PLATFORM_IOS_SIM=${PLATFORM_IOS_SIM}"/Developer/"
 SDK_IOS_VERSION=`ls "$PLATFORM_IOS/Developer/SDKs/" | ruby -e "p STDIN.read.split(/\s+/).map{|i| /[.\d]+/.match(i.gsub('.sdk', '')).to_a.first.to_f}.max"`
-MIN_IOS_VERSION="5.0"
+MIN_IOS_VERSION="6.0"

--- a/bin/build-exports.rb
+++ b/bin/build-exports.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-ENV['GEM_HOME'] = ENV['GEM_PATH'] = "/Library/Ruby/Gems/1.8"
+ENV['GEM_HOME'] = ENV['GEM_PATH'] = "/Library/Ruby/Gems/2.0.0"
 require 'rubygems'
 require 'nokogiri'
 
@@ -42,7 +42,7 @@ class BridgeMetadata
       if /[e\.]+/.match(e['value'])
         tt = 'd'
         val = [e['value'].to_f].pack('d')
-      elsif e['value'].to_i < 2^63
+      elsif e['value'].to_i < 2**63
         tt = 's'
         val = [e['value'].to_i].pack('q')
       end

--- a/bin/build-libffi.sh
+++ b/bin/build-libffi.sh
@@ -14,21 +14,22 @@ build_target () {
 
     mkdir -p "${builddir}"
     pushd "${builddir}"
-    export CC="${platform}"/Developer/usr/bin/gcc
+    export CC="${platform}"/usr/bin/gcc
     export CFLAGS="-g -Os \
     -arch ${arch} \
     -isysroot ${sdk} \
     -D__IPHONE_OS_VERSION_MIN_REQUIRED=50100 \
     -gdwarf-2  \
+    -no-integrated-as \
     -miphoneos-version-min=${MIN_IOS_VERSION}"
     autoreconf
     ../configure --host=${triple} && make
     popd
 }
 cd submodules/libffi
-build_target armv7 arm-apple-darwin10 armv7-ios "${PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
-build_target armv7s arm-apple-darwin10 armv7s-ios "${PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
-build_target i386 i386-apple-darwin10 i386-ios-sim "${PLATFORM_IOS_SIM}" "${PLATFORM_IOS_SIM}/Developer/SDKs/iPhoneSimulator${SDK_IOS_VERSION}.sdk/"
+build_target armv7 arm-apple-darwin10 armv7-ios "${GCC_PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
+build_target armv7s arm-apple-darwin10 armv7s-ios "${GCC_PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
+build_target i386 i386-apple-darwin10 i386-ios-sim "${GCC_PLATFORM_IOS_SIM}" "${PLATFORM_IOS_SIM}/Developer/SDKs/iPhoneSimulator${SDK_IOS_VERSION}.sdk/"
 
 
 # Create universal output directories

--- a/bin/build-libuv.sh
+++ b/bin/build-libuv.sh
@@ -8,7 +8,7 @@ build_target () {
     local platform=$2
     local sdk=$3
 
-    export CC="${platform}"/Developer/usr/bin/gcc
+    export CC="${platform}"/usr/bin/gcc
     export CFLAGS="-g -Os \
     -arch ${arch} \
     -isysroot ${sdk} \
@@ -24,9 +24,9 @@ cd submodules/libuv
 # remove process title property
 echo "int uv__set_process_title(const char* title) { return -1; }" > "src/unix/darwin-proctitle.m"
 
-build_target armv7 "${PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
-build_target armv7s "${PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
-build_target i386 "${PLATFORM_IOS_SIM}" "${PLATFORM_IOS_SIM}/Developer/SDKs/iPhoneSimulator${SDK_IOS_VERSION}.sdk/"
+build_target armv7 "${GCC_PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
+build_target armv7s "${GCC_PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
+build_target i386 "${GCC_PLATFORM_IOS_SIM}" "${PLATFORM_IOS_SIM}/Developer/SDKs/iPhoneSimulator${SDK_IOS_VERSION}.sdk/"
 
 
 # Create universal output directories

--- a/bin/build-mruby-framework.sh
+++ b/bin/build-mruby-framework.sh
@@ -28,7 +28,7 @@ build_target () {
     pushd modules/mruby
     mkdir -p "${builddir}"
     make clean
-    export CC="${platform}"/Developer/usr/bin/gcc
+    export CC="${platform}"/usr/bin/gcc
     export CFLAGS="-arch ${arch} -isysroot ${sdk} -D ALLOC_PADDING=8 -miphoneos-version-min=${MIN_IOS_VERSION} -g -O3"
     make CC="${CC}" CFLAGS="${CFLAGS}" -C src
     make CC="${CC}" CFLAGS="${CFLAGS}" MRBC="${MRBC}" CAT="/bin/cat" CP="/bin/cp" AR="/usr/bin/ar" -C mrblib
@@ -36,9 +36,9 @@ build_target () {
     popd
 }
 
-build_target armv6 arm-apple-darwin10 armv6-ios "${PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
-build_target armv7 arm-apple-darwin10 armv7-ios "${PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
-build_target i386 i386-apple-darwin10 i386-ios-sim "${PLATFORM_IOS_SIM}" "${PLATFORM_IOS_SIM}/Developer/SDKs/iPhoneSimulator${SDK_IOS_VERSION}.sdk/"
+build_target armv6 arm-apple-darwin10 armv6-ios "${GCC_PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
+build_target armv7 arm-apple-darwin10 armv7-ios "${GCC_PLATFORM_IOS}" "${PLATFORM_IOS}/Developer/SDKs/iPhoneOS${SDK_IOS_VERSION}.sdk/"
+build_target i386 i386-apple-darwin10 i386-ios-sim "${GCC_PLATFORM_IOS_SIM}" "${PLATFORM_IOS_SIM}/Developer/SDKs/iPhoneSimulator${SDK_IOS_VERSION}.sdk/"
 
 
 # Where we'll put the build framework.

--- a/build-libmruby.rb
+++ b/build-libmruby.rb
@@ -64,6 +64,7 @@ IOS_SIM_SDK = "#{PLATFORM_IOS_SIM}/Developer/SDKs/iPhoneSimulator#{SDK_IOS_VERSI
 
       conf.gem "#{BASEDIR}/submodules/mruby-uv"
       conf.gem "#{BASEDIR}/submodules/mruby-http"
+      conf.gem "#{BASEDIR}/submodules/mruby/mrbgems/mruby-eval"
     end
   end
 end

--- a/mobiruby-ios.xcodeproj/project.pbxproj
+++ b/mobiruby-ios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F3D667E18897FD8008893B8 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F3D667D18897FD8008893B8 /* MobileCoreServices.framework */; };
 		59008790165E911700F45C24 /* AFHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 5900877E165E911700F45C24 /* AFHTTPClient.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		59008791165E911700F45C24 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 59008780165E911700F45C24 /* AFHTTPRequestOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		59008792165E911700F45C24 /* AFImageRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 59008782165E911700F45C24 /* AFImageRequestOperation.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -63,6 +64,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2F3D667D18897FD8008893B8 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		5900877D165E911700F45C24 /* AFHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPClient.h; sourceTree = "<group>"; };
 		5900877E165E911700F45C24 /* AFHTTPClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AFHTTPClient.m; sourceTree = "<group>"; };
 		5900877F165E911700F45C24 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AFHTTPRequestOperation.h; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2F3D667E18897FD8008893B8 /* MobileCoreServices.framework in Frameworks */,
 				59088517170321A60058F1FA /* libsqlite3.dylib in Frameworks */,
 				59ACFC6D15FDBA22004BE69E /* QuartzCore.framework in Frameworks */,
 				59ACFC6B15FDBA15004BE69E /* AVFoundation.framework in Frameworks */,
@@ -235,6 +238,7 @@
 		5921A3A115FDB2E8007FECF1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				2F3D667D18897FD8008893B8 /* MobileCoreServices.framework */,
 				59ACFC6C15FDBA22004BE69E /* QuartzCore.framework */,
 				59ACFC6A15FDBA15004BE69E /* AVFoundation.framework */,
 				59ACFC6815FDBA11004BE69E /* SystemConfiguration.framework */,
@@ -323,8 +327,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5921A3B615FDB2E8007FECF1 /* Build configuration list for PBXNativeTarget "mobiruby-ios" */;
 			buildPhases = (
-				5921A39A15FDB2E8007FECF1 /* Sources */,
 				59ACFC6E15FDBA41004BE69E /* Generate export_headers.m */,
+				5921A39A15FDB2E8007FECF1 /* Sources */,
 				5921A39B15FDB2E8007FECF1 /* Frameworks */,
 				5921A39C15FDB2E8007FECF1 /* Resources */,
 			);

--- a/src/app.rb
+++ b/src/app.rb
@@ -6,8 +6,8 @@ class Cocoa::AppDelegate < Cocoa::UIResponder
         screen_rect = Cocoa::UIScreen._mainScreen._bounds
         @window = Cocoa::UIWindow._alloc._initWithFrame screen_rect
         @navi = Cocoa::UINavigationController._alloc._initWithNibName nil, :bundle, nil
-        @window._addSubview @navi._view
         @window._makeKeyAndVisible
+        @window._setRootViewController(@navi)
         show_tableview_menu(@navi)
         # show_samegame(@navi)
     end

--- a/src/editor.rb
+++ b/src/editor.rb
@@ -1,6 +1,8 @@
 require 'script_runner'
 
 class Cocoa::ScriptRunnerViewController < Cocoa::UIViewController
+  attr_accessor(:script)
+
   define C::Void, :loadView do
     _super :_loadView
     self._setTitle "Running"
@@ -19,11 +21,13 @@ class Cocoa::ScriptRunnerViewController < Cocoa::UIViewController
     @view._addSubview @console_view
   end
 
-  define C::Void, :runScript, Cocoa::Object do |script|
+  define C::Void, :viewDidAppear, C::Int do |animated|
+    _super :_viewDidAppear, animated
+
     $console_view = @console_view
     $console_view[:text] = ''
     begin
-      eval script._UTF8String.to_s
+      eval self.script.to_s
     rescue => e
       p e
     ensure
@@ -110,8 +114,8 @@ Cocoa::EditorViewController.register
 
 def show_script_runner(navi, script)
   viewController = Cocoa::ScriptRunnerViewController._alloc._init
+  viewController.script = script
   navi._pushViewController viewController, :animated, C::SInt8(1)
-  viewController._runScript _S(script)
 end
 
 def show_editor(navi)


### PR DESCRIPTION
- tested with Xcode 5.0.2 and iOS 7 simulator
- make mruby-eval enabled since editor.rb contains eval method
- conform the build script to the absence of iPhoneOS.platform/Developer/usr/bin/gcc
